### PR TITLE
[Model] new cosmos model with marginalized theta

### DIFF
--- a/tapqir/commands/config.py
+++ b/tapqir/commands/config.py
@@ -32,6 +32,7 @@ class Config(Command):
         config["fit"]["num_states"] = "1"
         config["fit"]["k_max"] = "2"
         config["fit"]["num_iter"] = "20000"
+        config["fit"]["infer"] = "0"
         config["fit"]["batch_size"] = "8"
         config["fit"]["learning_rate"] = "0.005"
         config["fit"]["control"] = "False"

--- a/tapqir/commands/fit.py
+++ b/tapqir/commands/fit.py
@@ -35,7 +35,9 @@ class Fit(Command):
         parser.add_argument("-k", metavar="K_MAX", type=int,
                             help="Maximum number of spots (default: 2)")
         parser.add_argument("-it", metavar="NUM_ITER", type=int,
-                            help="Number of iterations (default: 20000)")
+                            help="Number of iterations (default: 30000)")
+        parser.add_argument("-infer", metavar="INFER", type=int,
+                            help="Number of inference iterations (default: 20000)")
         parser.add_argument("-bs", metavar="BATCH_SIZE", type=int,
                             help="Batch size (default: 5)")
         parser.add_argument("-lr", metavar="LEARNING_RATE", type=float,
@@ -57,6 +59,7 @@ class Fit(Command):
         states = args.s or config["fit"].getint("num_states")
         k_max = args.k or config["fit"].getint("k_max")
         num_iter = args.it or config["fit"].getint("num_iter")
+        infer = args.infer or config["fit"].getint("infer")
         batch_size = args.bs or config["fit"].getint("batch_size")
         learning_rate = args.lr or config["fit"].getfloat("learning_rate")
         control = args.c or config["fit"].getboolean("control")
@@ -70,4 +73,4 @@ class Fit(Command):
         model = models[args.model](states, k_max)
         model.load(args.dataset_path, control, device)
         model.settings(learning_rate, batch_size)
-        model.run(num_iter)
+        model.run(num_iter, infer)

--- a/tapqir/models/__init__.py
+++ b/tapqir/models/__init__.py
@@ -1,8 +1,8 @@
 from tapqir.models.model import GaussianSpot
 from tapqir.models.model import Model
+from tapqir.models.cosmos import Cosmos
 from tapqir.models.spotdetection import SpotDetection
 from tapqir.models.fixedoffset import FixedOffset
-from tapqir.models.cosmos import Cosmos
 
 __all__ = [
     "GaussianSpot",

--- a/tapqir/models/model.py
+++ b/tapqir/models/model.py
@@ -11,6 +11,7 @@ from pyro.infer import JitTraceEnum_ELBO, TraceEnum_ELBO
 from pyro.ops.indexing import Vindex
 from pyro.ops.stats import quantile
 from torch.utils.tensorboard import SummaryWriter
+from torch.distributions.utils import probs_to_logits, logits_to_probs
 from sklearn.metrics import matthews_corrcoef, confusion_matrix, \
     recall_score, precision_score
 import logging
@@ -122,6 +123,7 @@ class Model(nn.Module):
         self.data.offset = torch.clamp(self.data.offset, offset_min, offset_max)
         self.offset_samples, self.offset_weights = torch.unique(self.data.offset, sorted=True, return_counts=True)
         self.offset_weights = self.offset_weights.float() / self.offset_weights.sum()
+        self.offset_logits = probs_to_logits(self.offset_weights)
         self.offset_mean = torch.sum(self.offset_samples * self.offset_weights)
         self.offset_var = torch.sum(self.offset_samples ** 2 * self.offset_weights) - self.offset_mean ** 2
 
@@ -155,8 +157,9 @@ class Model(nn.Module):
             self.predictions = np.zeros(
                 (self.data.N, self.data.F),
                 dtype=[("z", bool),
-                       ("z_prob", float), ("m", bool, (2,)),
-                       ("m_prob", float, (2,)), ("theta", int)])
+                       ("z_probs", float), ("m", bool, (2,)),
+                       ("m_probs", float, (2,)), ("theta", int)])
+        self._z_map = torch.zeros(self.data.N, self.data.F, dtype=torch.bool)
 
         self.elbo = (JitTraceEnum_ELBO if jit else TraceEnum_ELBO)(
             max_plate_nesting=2, ignore_jit_warnings=True)
@@ -174,11 +177,15 @@ class Model(nn.Module):
         """
         raise NotImplementedError
 
-    def run(self, num_iter):
-        # pyro.enable_validation()
+    def run(self, num_iter, infer):
         for i in tqdm(range(num_iter)):
-            # with torch.autograd.detect_anomaly():
-            # import pdb; pdb.set_trace()
+            self.iter_loss = self.svi.step()
+            if not self.iter % 100:
+                self.save_checkpoint()
+            self.iter += 1
+
+        self.classify = True
+        for i in tqdm(range(infer)):
             self.iter_loss = self.svi.step()
             if not self.iter % 100:
                 self.save_checkpoint()
@@ -223,8 +230,6 @@ class Model(nn.Module):
             if torch.isnan(v).any() or torch.isinf(v).any():
                 # import pdb; pdb.set_trace()
                 raise ValueError("Step #{}. Detected NaN values in {}".format(self.iter, k))
-        # if any([torch.isnan(v).any()
-        #         for v in pyro.get_param_store().values()]):
 
         # save parameters and optimizer state
         pyro.get_param_store().save(os.path.join(self.path, "params"))
@@ -272,9 +277,9 @@ class Model(nn.Module):
                 for key, value in scalars.items():
                     global_params["{}_{}".format(name, key)] = value
 
-        if self.data.labels is not None and self.name == "spotdetection":
+        if self.data.labels is not None:
             mask = self.data.labels["z"] < 2
-            pred_labels = (self.z_marginal > 0.5).cpu().numpy()[mask]
+            pred_labels = self.z_map.cpu().numpy()[mask]
             true_labels = self.data.labels["z"][mask]
 
             metrics = {}
@@ -298,7 +303,7 @@ class Model(nn.Module):
             try:
                 atten_labels = np.copy(self.data.labels)
                 atten_labels["z"][
-                    self.data.labels["spotpicker"] != (self.z_marginal > 0.5)] = 2
+                    self.data.labels["spotpicker"] != self.z_map] = 2
                 atten_labels["spotpicker"] = 0
                 np.save(os.path.join(self.path, "atten_labels.npy"),
                         atten_labels)
@@ -330,10 +335,8 @@ class Model(nn.Module):
         pyro.get_param_store().load(
             os.path.join(path, "params"),
             map_location=self.device)
-        self._K = 2 # param("d/h_loc").shape[-1]
+        self._K = 2
         self._S = 1
-        # self._S = len(param("probs_z")) - 1
-        # self.predictions = np.load(os.path.join(path, "predictions.npy"))
 
     def snr(self):
         r"""

--- a/tapqir/models/spotdetection.py
+++ b/tapqir/models/spotdetection.py
@@ -108,6 +108,10 @@ class SpotDetection(Model):
     def z_marginal(self):
         return self.z_probs.sum(-3)
 
+    @property
+    def z_map(self):
+        return self.z_marginal > 0.5
+
     @poutine.block(hide=["width_mean", "width_size", "proximity"])
     def model(self):
         # initialize model parameters


### PR DESCRIPTION
This is a new model named `cosmos` and intended to replace `spotdetection` used for co-localization experiments. `cosmos` is same as `spotdetection` with following differences:
- `theta` is marginalized out in the model
- as a consequence `m_{kdx}` are independent of `theta` in the guide
- `proximity` is a floated model parameter (see below)

Marginalizing `theta` makes the model better at finding off-target spots (seen from individual images and from higher `rate_j` values which are more accurate based on simulated data). Based on these it seems reasonable to float `proximity` parameter as well and expect its accurate estimate. This needs to be tested on various datasets.

**TODO**

- [x] implement a classifier for `theta` (probabilistic and map estimate)