### PR TITLE
automate batch_size

### DIFF
--- a/tapqir/commands/config.py
+++ b/tapqir/commands/config.py
@@ -33,7 +33,7 @@ class Config(Command):
         config["fit"]["k_max"] = "2"
         config["fit"]["num_iter"] = "30000"
         config["fit"]["infer"] = "10000"
-        config["fit"]["batch_size"] = "5"
+        config["fit"]["batch_size"] = "0"
         config["fit"]["learning_rate"] = "0.005"
         config["fit"]["control"] = "True"
         config["fit"]["device"] = "cuda"

--- a/tapqir/commands/fit.py
+++ b/tapqir/commands/fit.py
@@ -72,5 +72,30 @@ class Fit(Command):
 
         model = models[args.model](states, k_max)
         model.load(args.dataset_path, control, device)
+
+        # find max possible batch_size
+        if batch_size == 0:
+            import shutil
+            k = 0
+            while batch_size < model.data.N:
+                model.settings(learning_rate, batch_size + 2**k)
+                try:
+                    model.run(1, 1)
+                except RuntimeError as error:
+                    assert error.args[0].startswith("CUDA")
+                    shutil.rmtree(model.path)
+                    if k == 0:
+                        break
+                    else:
+                        batch_size += 2**(k-1)
+                        k = 0
+                else:
+                    shutil.rmtree(model.path)
+                    k += 1
+            # add batch_size to options.cfg
+            config.set("fit", "batch_size", str(batch_size))
+            with open(cfg_file, "w") as configfile:
+                config.write(configfile)
+
         model.settings(learning_rate, batch_size)
         model.run(num_iter, infer)


### PR DESCRIPTION
This simple algorithm automates finding max `batch_size` possible by catching `RuntimeError` exceptions. The algorithm is triggered when the `batch_size` is set to zero.