### PR TITLE
Improve fitting stability by clipping parameters with eps

### DIFF
--- a/tapqir/models/cosmos.py
+++ b/tapqir/models/cosmos.py
@@ -374,8 +374,8 @@ class Cosmos(Model):
             "proximity_loc",
             lambda: torch.tensor(0.5),
             constraint=constraints.interval(
-                0,
-                (self.data.D + 1) / math.sqrt(12)) - torch.finfo(torch.float32).eps,
+                0, (self.data.D + 1) / math.sqrt(12) - torch.finfo(torch.float32).eps
+            ),
         )
         pyro.param("gain_loc", lambda: torch.tensor(5), constraint=constraints.positive)
         pyro.param(


### PR DESCRIPTION
Clip `proximity_loc`, `w_mean`, `x_mean`, and `y_mean` by `eps`. This improves fitting stability by avoiding `nan` in `AffineBeta.log_prob`.