### PR TITLE
Set pykeops verbosity=0

### DIFF
--- a/tapqir/distributions/ksmogn.py
+++ b/tapqir/distributions/ksmogn.py
@@ -84,7 +84,7 @@ class KSMOGN(TorchDistribution):
     ):
 
         gaussians = gaussian_spots(height, width, x, y, target_locs.unsqueeze(-2), P, m)
-        image = background[..., None, None] * (1 + gaussians.sum(-3))
+        image = background[..., None, None] + gaussians.sum(-3)
 
         self.concentration = image / gain[..., None, None]
         self.rate = 1 / gain[..., None, None]

--- a/tapqir/distributions/ksmogn.py
+++ b/tapqir/distributions/ksmogn.py
@@ -16,7 +16,7 @@ from torch.distributions import Categorical, constraints
 
 from .util import gaussian_spots
 
-os.environ["PYKEOPS_VERBOSE"] = 0
+os.environ["PYKEOPS_VERBOSE"] = "0"
 
 
 class KSMOGN(TorchDistribution):
@@ -84,7 +84,7 @@ class KSMOGN(TorchDistribution):
     ):
 
         gaussians = gaussian_spots(height, width, x, y, target_locs.unsqueeze(-2), P, m)
-        image = background[..., None, None] + gaussians.sum(-3)
+        image = background[..., None, None] * (1 + gaussians.sum(-3))
 
         self.concentration = image / gain[..., None, None]
         self.rate = 1 / gain[..., None, None]

--- a/tapqir/distributions/ksmogn.py
+++ b/tapqir/distributions/ksmogn.py
@@ -6,9 +6,9 @@ KSMOGN
 ^^^^^^
 """
 
-import os
 from typing import Union
 
+import pykeops
 import torch
 from pykeops.torch import Genred
 from pyro.distributions import TorchDistribution
@@ -16,7 +16,7 @@ from torch.distributions import Categorical, constraints
 
 from .util import gaussian_spots
 
-os.environ["PYKEOPS_VERBOSE"] = "0"
+pykeops.set_verbose(False)
 
 
 class KSMOGN(TorchDistribution):

--- a/tapqir/distributions/ksmogn.py
+++ b/tapqir/distributions/ksmogn.py
@@ -6,6 +6,7 @@ KSMOGN
 ^^^^^^
 """
 
+import os
 from typing import Union
 
 import torch
@@ -14,6 +15,8 @@ from pyro.distributions import TorchDistribution
 from torch.distributions import Categorical, constraints
 
 from .util import gaussian_spots
+
+os.environ["PYKEOPS_VERBOSE"] = 0
 
 
 class KSMOGN(TorchDistribution):


### PR DESCRIPTION
Disable pykeops compilation message. Normally when tapqir is run for the first time pykeops produces compilation message:

```
[KeOps] Generating code for formula Max_SumShiftExpWeight_Reduction(Concat(((Var(0,1,1)+Log(Step((Var(4,1,0)-Var(1,1,1))-1)))+(Var(2,1,0)-1)*Log(IfElse((Var(4,1,0)-Var(1,1,1))-1,Var(4,1,0)-Var(1,1,1),Var(4,1,0))))-Var(3,1,0)*(Var(4,1,0)-Var(1,1,1)),1),0) ... OK
[KeOps] Generating code for formula Sum_Reduction(Log(IfElse((Var(4,1,0)-Var(1,1,1))-1,Var(4,1,0)-Var(1,1,1),Var(4,1,0)))*(Extract(Var(5,2,0),1,1)*Exp((((Var(0,1,1)+Log(Step((Var(4,1,0)-Var(1,1,1))-1)))+(Var(2,1,0)-1)*Log(IfElse((Var(4,1,0)-Var(1,1,1))-1,Var(4,1,0)-Var(1,1,1),Var(4,1,0))))-Var(3,1,0)*(Var(4,1,0)-Var(1,1,1)))-Extract(Var(6,2,0),0,1)))+IfElse((Var(4,1,0)-Var(1,1,1))-1,Zero(1),Zero(1)),0) ... OK
[KeOps] Generating code for formula Sum_Reduction(IfElse((Var(4,1,0)-Var(1,1,1))-1,Zero(1),Zero(1))-(Var(4,1,0)-Var(1,1,1))*(Extract(Var(5,2,0),1,1)*Exp((((Var(0,1,1)+Log(Step((Var(4,1,0)-Var(1,1,1))-1)))+(Var(2,1,0)-1)*Log(IfElse((Var(4,1,0)-Var(1,1,1))-1,Var(4,1,0)-Var(1,1,1),Var(4,1,0))))-Var(3,1,0)*(Var(4,1,0)-Var(1,1,1)))-Extract(Var(6,2,0),0,1))),0) ... OK
```