### PR TITLE
Fix google colab install

### DIFF
--- a/docs/source/install/linux.rst
+++ b/docs/source/install/linux.rst
@@ -123,7 +123,7 @@ We have tested Tapqir installation on Ubuntu 20.04 and Arch Linux distributions.
 
 8. Install ``tapqir``::
 
-    $ pip install tapqir
+    $ pip install tapqir[desktop]
 
 .. tip::
 

--- a/docs/source/install/windows.rst
+++ b/docs/source/install/windows.rst
@@ -85,7 +85,7 @@ Install on Windows 11
 
 8. Install ``tapqir``::
 
-    $ pip install tapqir
+    $ pip install tapqir[desktop]
 
 Now you can run Tapqir in the WSL window in the same way you would on a linux computer.
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ DOCS_REQUIRE = [
     "sphinx-gallery",
     "sphinx-panels",
 ]
-DESKTOP_REQUIRE = ["tensorboard", "voila"]
+DESKTOP_REQUIRE = ["voila"]
 
 setuptools.setup(
     name="tapqir",
@@ -74,6 +74,7 @@ setuptools.setup(
         "pyyaml>=6.0",
         "scikit-learn",
         "scipy",
+        "tensorboard",
         "torch==1.10.0",
         "typer",
     ],

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[
+        "click<=8.0.4",
         "colorama",
         "funsor==0.4.2",
         "future",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ DOCS_REQUIRE = [
     "sphinx-gallery",
     "sphinx-panels",
 ]
-IN_COLAB = "COLAB_GPU" in os.environ
+DESKTOP_REQUIRE = ["tensorboard", "voila"]
 
 setuptools.setup(
     name="tapqir",
@@ -66,7 +66,6 @@ setuptools.setup(
         "ipyfilechooser",
         "ipympl",
         "ipywidgets",
-        "jinja2<=3.0.3",
         "matplotlib",
         "pandas",
         "pykeops>=2.0",
@@ -76,13 +75,13 @@ setuptools.setup(
         "scipy",
         "torch==1.10.0",
         "typer",
-    ]
-    + ([] if IN_COLAB else ["tensorboard", "voila"]),
+    ],
     extras_require={
+        "desktop": DESKTOP_REQUIRE,
         "extras": EXTRAS_REQUIRE,
         "test": EXTRAS_REQUIRE + TEST_REQUIRE,
         "docs": DOCS_REQUIRE,
-        "dev": EXTRAS_REQUIRE + TEST_REQUIRE + DOCS_REQUIRE,
+        "dev": DESKTOP_REQUIRE + EXTRAS_REQUIRE + TEST_REQUIRE + DOCS_REQUIRE,
     },
     keywords="image-classification probabilistic-programming cosmos pyro",
     license="Apache 2.0",


### PR DESCRIPTION
This fixes tapqir installation warnings on google colab.

To install on desktop computers now need to run `pip install tapqir[desktop]`