### PR TITLE
Optimize `Cosmos.compute_probs`

### DIFF
--- a/tapqir/distributions/ksmogn.py
+++ b/tapqir/distributions/ksmogn.py
@@ -13,6 +13,7 @@ import torch
 from pykeops.torch import Genred
 from pyro.distributions import TorchDistribution
 from torch.distributions import Categorical, constraints
+from torch.distributions.utils import lazy_property
 
 from .util import gaussian_spots
 
@@ -83,21 +84,55 @@ class KSMOGN(TorchDistribution):
         validate_args=None,
     ):
 
-        gaussians = gaussian_spots(height, width, x, y, target_locs.unsqueeze(-2), P, m)
-        image = background[..., None, None] + gaussians.sum(-3)
+        self.height = height
+        self.width = width
+        self.x = x
+        self.y = y
+        self.target_locs = target_locs
+        self.background = background
+        self.gain = gain
+        self.m = m
 
-        self.concentration = image / gain[..., None, None]
         self.rate = 1 / gain[..., None, None]
         self.offset_samples = offset_samples
         self.offset_logits = offset_logits
         self.P = P
         self.use_pykeops = use_pykeops
         if self.use_pykeops:
-            device = self.concentration.device.type
+            device = self.target_locs.device.type
             self.device_pykeops = "GPU" if device == "cuda" else "CPU"
-        batch_shape = image.shape[:-2]
-        event_shape = image.shape[-2:]
+
+        # calculate batch shape
+        batch_shape = torch.broadcast_shapes(
+            height.shape, width.shape, x.shape, y.shape
+        )
+        if m is not None:
+            batch_shape = torch.broadcast_shapes(batch_shape, m.shape)
+        batch_shape = torch.broadcast_shapes(
+            batch_shape[:-1], background.shape, target_locs.shape[:-1]
+        )
+        event_shape = torch.Size([P, P])
         super().__init__(batch_shape, event_shape, validate_args=validate_args)
+
+    @lazy_property
+    def gaussians(self):
+        return gaussian_spots(
+            self.height,
+            self.width,
+            self.x,
+            self.y,
+            self.target_locs.unsqueeze(-2),
+            self.P,
+            self.m,
+        )
+
+    @lazy_property
+    def image(self):
+        return self.background[..., None, None] + self.gaussians.sum(-3)
+
+    @lazy_property
+    def concentration(self):
+        return self.image / self.gain[..., None, None]
 
     def rsample(self, sample_shape=torch.Size()):
         odx = (

--- a/tapqir/models/cosmos.py
+++ b/tapqir/models/cosmos.py
@@ -590,11 +590,13 @@ class Cosmos(Model):
                 self.nbatch_size = len(ndx)
                 self.fbatch_size = len(fdx)
                 with torch.no_grad(), pyro.plate(
-                    "particles", size=25, dim=-3
+                    "particles", size=50, dim=-3
                 ), handlers.enum(first_available_dim=-4):
                     guide_tr = handlers.trace(self.guide).get_trace()
                     model_tr = handlers.trace(
-                        handlers.replay(self.model, trace=guide_tr)
+                        handlers.replay(
+                            handlers.block(self.model, hide=["data"]), trace=guide_tr
+                        )
                     ).get_trace()
                 model_tr.compute_log_prob()
                 guide_tr.compute_log_prob()


### PR DESCRIPTION
* `.compute_probs` is used to calculate `z_probs` and `theta_probs`.
* This optimizes its computation; on DatasetA it sped it up from 65s to 4s.
* Increased number of Monte Carlo samples from 25 to 50